### PR TITLE
Sort by Categories, add Goofy and Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
   - https://github.com/Voluntarynet/Bitpost
 - **fb-mac-messenger**: Mac wrapper for Facebook messenger
   - https://github.com/rsms/fb-mac-messenger
+- **Goofy**: OS X client for Facebook Messenger
+  - https://github.com/danielbuechele/goofy
 - **WhatsMac**: A native Mac app wrapper for WhatsApp Web
   - https://github.com/stonesam92/WhatsMac
 
 #### Editors
+- **Atom**: The hackable text editor
+  - https://github.com/atom/atom
 - **macdown**: Markdown editor
   - https://github.com/uranusjr/macdown
 - **TipTyper**: Simple plain-text editor for OS X with multiple useful features

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
   - https://github.com/kykim/rem
 - **Resign**: OSX utility to resign the IPA files
   - https://github.com/LigeiaRowena/Resign
+- **Unused** - A Mac app for checking Xcode projects for unused resources
+  - https://github.com/jeffhodnett/Unused
 - **VisualJSON**: JSON pretty-viewer for OS X.
   - https://github.com/youknowone/VisualJSON
 

--- a/README.md
+++ b/README.md
@@ -3,103 +3,103 @@
 List of open-source Mac apps.  Managed by [Jeffrey Jackson](https://github.com/jeffreyjackson)
 
 Feel free to contribute: [issues](https://github.com/jeffreyjackson/mac-apps/issues) or [pull requests](https://github.com/jeffreyjackson/mac-apps/pulls).
- 
+
 :large_orange_diamond: Swift projects
 
 ### OS X Frameworks
 
 Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://github.com/jeffreyjackson/mac-frameworks)
- 
+
 ### OS X Apps
-- Adium: Instant Messaging Client
+- **Adium**: Instant Messaging Client
   - https://github.com/adium/adium
-- AnyBar: OS X menubar status indicator
+- **AnyBar**: OS X menubar status indicator
   - https://github.com/tonsky/AnyBar
-- App Reviews: App Reviews help you keep track of user reviews for your iPhone Apps. :large_orange_diamond:
+- **App** Reviews: App Reviews help you keep track of user reviews for your iPhone Apps. :large_orange_diamond:
   - https://github.com/knutigro/AppReviews
-- Awake: An app for mac osx to prevent sleeping; inspired by Caffeine.
+- **Awake**: An app for mac osx to prevent sleeping; inspired by Caffeine.
   - https://github.com/xiaozi/Awake.app
-- Bitpost: OSX app for Bitmessage
+- **Bitpost**: OSX app for Bitmessage
   - https://github.com/Voluntarynet/Bitpost
-- Cakebrew: Manage your Homebrew formulas with style
+- **Cakebrew**: Manage your Homebrew formulas with style
   - https://github.com/brunophilipe/Cakebrew
-- Catch: Broadcasting made easy.
+- **Catch**: Broadcasting made easy.
   - https://github.com/mipstian/catch
-- Clock-Saver: Simple clock screensaver :large_orange_diamond:
+- **Clock**-Saver: Simple clock screensaver :large_orange_diamond:
   - https://github.com/soffes/clock-saver
-- Cloudy: mac app wrapper for overcast :large_orange_diamond:
-  - https://github.com/calebd/cloudy 
-- Cocoapods App: A full-featured and standalone installation of CocoaPods
+- **Cloudy**: mac app wrapper for overcast :large_orange_diamond:
+  - https://github.com/calebd/cloudy
+- **Cocoapods** App: A full-featured and standalone installation of CocoaPods
   - https://github.com/CocoaPods/CocoaPods-app
-- CocoaRestClient: A free, native Apple OS X app for testing HTTP/REST endpoints
-  - https://github.com/mmattozzi/cocoa-rest-client 
-- CoinManager: OS X app for Coinbase
+- **CocoaRestClient**: A free, native Apple OS X app for testing HTTP/REST endpoints
+  - https://github.com/mmattozzi/cocoa-rest-client
+- **CoinManager**: OS X app for Coinbase
   - https://github.com/D-32/CoinManager
-- Color Picker Pro: Color Detection Tool for Designers and Developers
-  - https://github.com/oscardelben/Color-Picker-Pro 
-- dshb: OS X system monitor in Swift :large_orange_diamond:
+- **Color** Picker Pro: Color Detection Tool for Designers and Developers
+  - https://github.com/oscardelben/Color-Picker-Pro
+- **dshb**: OS X system monitor in Swift :large_orange_diamond:
   - https://github.com/beltex/dshb
-- fb-mac-messenger: Mac wrapper for Facebook messenger
+- **fb**-mac-messenger: Mac wrapper for Facebook messenger
   - https://github.com/rsms/fb-mac-messenger
-- Freecell: Solitaire type card game for OS X
+- **Freecell**: Solitaire type card game for OS X
   - https://github.com/alisdair/freecell
-- Gifs: A Mac App for finding GIFs
+- **Gifs**: A Mac App for finding GIFs
   - https://github.com/orta/gifs
-- GoogleMusicMac: Wrapper for Google Music that is compatible with the Mac's media keys.
+- **GoogleMusicMac**: Wrapper for Google Music that is compatible with the Mac's media keys.
   - https://github.com/JamesFator/GoogleMusicMac
-- Handbrake: Video/Audio encoder / decoder
+- **Handbrake**: Video/Audio encoder / decoder
   - https://github.com/HandBrake/HandBrake
-- Helium: A floating browser window for OS X
+- **Helium**: A floating browser window for OS X
   - https://github.com/JadenGeller/Helium
-- ImageAlpha: Mac GUI for pngquant, pngnq and posterizer
+- **ImageAlpha**: Mac GUI for pngquant, pngnq and posterizer
   - https://github.com/pornel/ImageAlpha
-- ImageOptim: GUI image optimizer for Mac
+- **ImageOptim**: GUI image optimizer for Mac
   - https://github.com/pornel/ImageOptim
-- iro: Color picker menu bar app for Mac OSX 10.9+
+- **iro**: Color picker menu bar app for Mac OSX 10.9+
   - https://github.com/ripeworks/iro
-- mac2imgur: Upload screenshots to imgur :large_orange_diamond:
+- **mac2imgur**: Upload screenshots to imgur :large_orange_diamond:
   - https://github.com/mileswd/mac2imgur
-- macdown: Markdown editor
+- **macdown**: Markdown editor
   - https://github.com/uranusjr/macdown
-- MactsAsBeacon: A tiny app to turn a Bluetooth LE-equipped Mac into an iBeacon
+- **MactsAsBeacon**: A tiny app to turn a Bluetooth LE-equipped Mac into an iBeacon
   - https://github.com/timd/MactsAsBeacon
-- mirrorapp: Mirror Enterprise iOS and OSX App
+- **mirrorapp**: Mirror Enterprise iOS and OSX App
   - https://github.com/psutlt/mirrorapp
-- my41cx: Microcode emulator for HP-41 C/CV/CX (OS X & iOS)
+- **my41cx**: Microcode emulator for HP-41 C/CV/CX (OS X & iOS)
   - https://github.com/mperovic/my41
-- MultiMarkdown version (with HTML source tab) of Notational Velocity
+- **MultiMarkdown** version (with HTML source tab) of Notational Velocity
   - https://github.com/ttscoff/nv
-- PNGSquash: A PNG compressor app for Mac OS X
+- **PNGSquash**: A PNG compressor app for Mac OS X
   - https://github.com/msanders/PNGSquash
-- Quicksilver: fast and free Mac OS X productivity application
+- **Quicksilver**: fast and free Mac OS X productivity application
   - https://github.com/quicksilver/Quicksilver
-- Rem: Command-line tool to access OSX Reminders.app database
+- **Rem**: Command-line tool to access OSX Reminders.app database
   - https://github.com/kykim/rem
-- Resign: OSX utility to resign the IPA files
+- **Resign**: OSX utility to resign the IPA files
   - https://github.com/LigeiaRowena/Resign
-- Screentendo: Turn your screen into a playable level of Mario
+- **Screentendo**: Turn your screen into a playable level of Mario
   - https://github.com/AaronRandall/Screentendo
-- Standalone Mac OS X browser for SoundCloud
+- **Standalone** Mac OS X browser for SoundCloud
   - https://github.com/salomvary/soundcleod
-- Spectacle: Organize your windows without using a mouse
+- **Spectacle**: Organize your windows without using a mouse
   - https://github.com/eczarny/spectacle
-- stockfish-mac: Beautiful, powerful chess app for the Mac
+- **stockfish**-mac: Beautiful, powerful chess app for the Mac
   - https://github.com/daylen/stockfish-mac
-- TipTyper: Simple plain-text editor for OS X with multiple useful features
+- **TipTyper**: Simple plain-text editor for OS X with multiple useful features
   - https://github.com/brunophilipe/TipTyper
-- ToDoOSX: OS X app using Parse and managing Todos
+- **ToDoOSX**: OS X app using Parse and managing Todos
   - https://github.com/ParsePlatform/TodoOSX
-- tunnelblick: Graphic user interface for OpenVPN 
+- **tunnelblick**: Graphic user interface for OpenVPN
   - https://code.google.com/p/tunnelblick/
-- VideoMessageExporter: OSX app to export Skype video messages
+- **VideoMessageExporter**: OSX app to export Skype video messages
   - https://github.com/alvarop/VideoMessageExporter
-- Vienna: RSS/Atom Reader
+- **Vienna**: RSS/Atom Reader
   - https://github.com/ViennaRSS/vienna-rss
-- VisualJSON: JSON pretty-viewer for OS X.
+- **VisualJSON**: JSON pretty-viewer for OS X.
   - https://github.com/youknowone/VisualJSON
-- WhatsMac: A native Mac app wrapper for WhatsApp Web
+- **WhatsMac**: A native Mac app wrapper for WhatsApp Web
   - https://github.com/stonesam92/WhatsMac
-- WWDC: WWDC app for OS X :large_orange_diamond:
+- **WWDC**: WWDC app for OS X :large_orange_diamond:
   - https://github.com/insidegui/WWDC
 
 ### Apple Sample Projects

--- a/README.md
+++ b/README.md
@@ -11,96 +11,111 @@ Feel free to contribute: [issues](https://github.com/jeffreyjackson/mac-apps/iss
 Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://github.com/jeffreyjackson/mac-frameworks)
 
 ### OS X Apps
+
+#### Communication
 - **Adium**: Instant Messaging Client
   - https://github.com/adium/adium
-- **AnyBar**: OS X menubar status indicator
-  - https://github.com/tonsky/AnyBar
-- **App** Reviews: App Reviews help you keep track of user reviews for your iPhone Apps. :large_orange_diamond:
-  - https://github.com/knutigro/AppReviews
-- **Awake**: An app for mac osx to prevent sleeping; inspired by Caffeine.
-  - https://github.com/xiaozi/Awake.app
 - **Bitpost**: OSX app for Bitmessage
   - https://github.com/Voluntarynet/Bitpost
+- **fb-mac-messenger**: Mac wrapper for Facebook messenger
+  - https://github.com/rsms/fb-mac-messenger
+- **WhatsMac**: A native Mac app wrapper for WhatsApp Web
+  - https://github.com/stonesam92/WhatsMac
+
+#### Editors
+- **macdown**: Markdown editor
+  - https://github.com/uranusjr/macdown
+- **TipTyper**: Simple plain-text editor for OS X with multiple useful features
+  - https://github.com/brunophilipe/TipTyper
+- MultiMarkdown version (with HTML source tab) of Notational Velocity
+  - https://github.com/ttscoff/nv
+
+#### Games
+- **Freecell**: Solitaire type card game for OS X
+  - https://github.com/alisdair/freecell
+- **Screentendo**: Turn your screen into a playable level of Mario
+  - https://github.com/AaronRandall/Screentendo
+- **stockfish-mac**: Beautiful, powerful chess app for the Mac
+  - https://github.com/daylen/stockfish-mac
+
+#### Mac Exclusives
+- **AnyBar**: OS X menubar status indicator
+  - https://github.com/tonsky/AnyBar
+- **Awake**: An app for mac osx to prevent sleeping; inspired by Caffeine.
+  - https://github.com/xiaozi/Awake.app
+- **Clock-Saver**: Simple clock screensaver :large_orange_diamond:
+  - https://github.com/soffes/clock-saver
+- **dshb**: OS X system monitor in Swift :large_orange_diamond:
+  - https://github.com/beltex/dshb
+- **Helium**: A floating browser window for OS X
+  - https://github.com/JadenGeller/Helium
+- **mirrorapp**: Mirror Enterprise iOS and OSX App
+  - https://github.com/psutlt/mirrorapp
+- **Quicksilver**: fast and free Mac OS X productivity application
+  - https://github.com/quicksilver/Quicksilver
+- **Spectacle**: Organize your windows without using a mouse
+  - https://github.com/eczarny/spectacle
+
+
+#### For Developers
+- **App Reviews**: App Reviews help you keep track of user reviews for your iPhone Apps. :large_orange_diamond:
+  - https://github.com/knutigro/AppReviews
 - **Cakebrew**: Manage your Homebrew formulas with style
   - https://github.com/brunophilipe/Cakebrew
-- **Catch**: Broadcasting made easy.
-  - https://github.com/mipstian/catch
-- **Clock**-Saver: Simple clock screensaver :large_orange_diamond:
-  - https://github.com/soffes/clock-saver
-- **Cloudy**: mac app wrapper for overcast :large_orange_diamond:
-  - https://github.com/calebd/cloudy
-- **Cocoapods** App: A full-featured and standalone installation of CocoaPods
+- **Cocoapods App**: A full-featured and standalone installation of CocoaPods
   - https://github.com/CocoaPods/CocoaPods-app
 - **CocoaRestClient**: A free, native Apple OS X app for testing HTTP/REST endpoints
   - https://github.com/mmattozzi/cocoa-rest-client
-- **CoinManager**: OS X app for Coinbase
-  - https://github.com/D-32/CoinManager
-- **Color** Picker Pro: Color Detection Tool for Designers and Developers
-  - https://github.com/oscardelben/Color-Picker-Pro
-- **dshb**: OS X system monitor in Swift :large_orange_diamond:
-  - https://github.com/beltex/dshb
-- **fb**-mac-messenger: Mac wrapper for Facebook messenger
-  - https://github.com/rsms/fb-mac-messenger
-- **Freecell**: Solitaire type card game for OS X
-  - https://github.com/alisdair/freecell
-- **Gifs**: A Mac App for finding GIFs
-  - https://github.com/orta/gifs
-- **GoogleMusicMac**: Wrapper for Google Music that is compatible with the Mac's media keys.
-  - https://github.com/JamesFator/GoogleMusicMac
-- **Handbrake**: Video/Audio encoder / decoder
-  - https://github.com/HandBrake/HandBrake
-- **Helium**: A floating browser window for OS X
-  - https://github.com/JadenGeller/Helium
-- **ImageAlpha**: Mac GUI for pngquant, pngnq and posterizer
-  - https://github.com/pornel/ImageAlpha
-- **ImageOptim**: GUI image optimizer for Mac
-  - https://github.com/pornel/ImageOptim
-- **iro**: Color picker menu bar app for Mac OSX 10.9+
-  - https://github.com/ripeworks/iro
-- **mac2imgur**: Upload screenshots to imgur :large_orange_diamond:
-  - https://github.com/mileswd/mac2imgur
-- **macdown**: Markdown editor
-  - https://github.com/uranusjr/macdown
-- **MactsAsBeacon**: A tiny app to turn a Bluetooth LE-equipped Mac into an iBeacon
-  - https://github.com/timd/MactsAsBeacon
-- **mirrorapp**: Mirror Enterprise iOS and OSX App
-  - https://github.com/psutlt/mirrorapp
-- **my41cx**: Microcode emulator for HP-41 C/CV/CX (OS X & iOS)
-  - https://github.com/mperovic/my41
-- **MultiMarkdown** version (with HTML source tab) of Notational Velocity
-  - https://github.com/ttscoff/nv
-- **PNGSquash**: A PNG compressor app for Mac OS X
-  - https://github.com/msanders/PNGSquash
-- **Quicksilver**: fast and free Mac OS X productivity application
-  - https://github.com/quicksilver/Quicksilver
 - **Rem**: Command-line tool to access OSX Reminders.app database
   - https://github.com/kykim/rem
 - **Resign**: OSX utility to resign the IPA files
   - https://github.com/LigeiaRowena/Resign
-- **Screentendo**: Turn your screen into a playable level of Mario
-  - https://github.com/AaronRandall/Screentendo
-- **Standalone** Mac OS X browser for SoundCloud
-  - https://github.com/salomvary/soundcleod
-- **Spectacle**: Organize your windows without using a mouse
-  - https://github.com/eczarny/spectacle
-- **stockfish**-mac: Beautiful, powerful chess app for the Mac
-  - https://github.com/daylen/stockfish-mac
-- **TipTyper**: Simple plain-text editor for OS X with multiple useful features
-  - https://github.com/brunophilipe/TipTyper
-- **ToDoOSX**: OS X app using Parse and managing Todos
-  - https://github.com/ParsePlatform/TodoOSX
-- **tunnelblick**: Graphic user interface for OpenVPN
-  - https://code.google.com/p/tunnelblick/
-- **VideoMessageExporter**: OSX app to export Skype video messages
-  - https://github.com/alvarop/VideoMessageExporter
-- **Vienna**: RSS/Atom Reader
-  - https://github.com/ViennaRSS/vienna-rss
 - **VisualJSON**: JSON pretty-viewer for OS X.
   - https://github.com/youknowone/VisualJSON
-- **WhatsMac**: A native Mac app wrapper for WhatsApp Web
-  - https://github.com/stonesam92/WhatsMac
+
+#### Tools
+- **Color Picker Pro**: Color Detection Tool for Designers and Developers
+  - https://github.com/oscardelben/Color-Picker-Pro
+- **Gifs**: A Mac App for finding GIFs
+  - https://github.com/orta/gifs
+- **Handbrake**: Video/Audio encoder / decoder
+  - https://github.com/HandBrake/HandBrake
+- **ImageAlpha**: Mac GUI for pngquant, pngnq and posterizer
+  - https://github.com/pornel/ImageAlpha
+- **iro**: Color picker menu bar app for Mac OSX 10.9+
+  - https://github.com/ripeworks/iro
+- **mac2imgur**: Upload screenshots to imgur :large_orange_diamond:
+  - https://github.com/mileswd/mac2imgur
+- **MactsAsBeacon**: A tiny app to turn a Bluetooth LE-equipped Mac into an iBeacon
+  - https://github.com/timd/MactsAsBeacon
+- **my41cx**: Microcode emulator for HP-41 C/CV/CX (OS X & iOS)
+  - https://github.com/mperovic/my41
+- **PNGSquash**: A PNG compressor app for Mac OS X
+  - https://github.com/msanders/PNGSquash
+- **VideoMessageExporter**: OSX app to export Skype video messages
+  - https://github.com/alvarop/VideoMessageExporter
+
+#### OS X versions, GUIs and other Wrappers
+- **Cloudy**: mac app wrapper for overcast :large_orange_diamond:
+  - https://github.com/calebd/cloudy
+- **CoinManager**: OS X app for Coinbase
+  - https://github.com/D-32/CoinManager
+- **GoogleMusicMac**: Wrapper for Google Music that is compatible with the Mac's media keys.
+  - https://github.com/JamesFator/GoogleMusicMac
+- **Soundcleod**: Standalone Mac OS X browser for SoundCloud
+  - https://github.com/salomvary/soundcleod
 - **WWDC**: WWDC app for OS X :large_orange_diamond:
   - https://github.com/insidegui/WWDC
+- **tunnelblick**: Graphic user interface for OpenVPN
+  - https://code.google.com/p/tunnelblick/
+
+#### Productivity and Others
+- **Catch**: Broadcasting made easy.
+  - https://github.com/mipstian/catch
+- **ToDoOSX**: OS X app using Parse and managing Todos
+  - https://github.com/ParsePlatform/TodoOSX
+- **Vienna**: RSS/Atom Reader
+  - https://github.com/ViennaRSS/vienna-rss
 
 ### Apple Sample Projects
 [Apple Sample Projects](https://developer.apple.com/library/mac/navigation/#section=Resource%20Types&topic=Sample%20Code)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
 ### Productivity and Others
 - **Catch**: Broadcasting made easy.
   - https://github.com/mipstian/catch
+- **Jekyll** Blog-aware, static site generator in Ruby
+  - https://github.com/jekyll/jekyll
 - **ToDoOSX**: OS X app using Parse and managing Todos
   - https://github.com/ParsePlatform/TodoOSX
 - **Vienna**: RSS/Atom Reader

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Feel free to contribute: [issues](https://github.com/jeffreyjackson/mac-apps/iss
 
 :large_orange_diamond: Swift projects
 
-### OS X Frameworks
+## OS X Frameworks
 
 Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://github.com/jeffreyjackson/mac-frameworks)
 
-### OS X Apps
+## OS X Apps
 
-#### Communication
+### Communication
 - **Adium**: Instant Messaging Client
   - https://github.com/adium/adium
 - **Bitpost**: OSX app for Bitmessage
@@ -24,7 +24,7 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
 - **WhatsMac**: A native Mac app wrapper for WhatsApp Web
   - https://github.com/stonesam92/WhatsMac
 
-#### Editors
+### Editors
 - **Atom**: The hackable text editor
   - https://github.com/atom/atom
 - **macdown**: Markdown editor
@@ -34,7 +34,7 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
 - MultiMarkdown version (with HTML source tab) of Notational Velocity
   - https://github.com/ttscoff/nv
 
-#### Games
+### Games
 - **Freecell**: Solitaire type card game for OS X
   - https://github.com/alisdair/freecell
 - **Screentendo**: Turn your screen into a playable level of Mario
@@ -42,7 +42,7 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
 - **stockfish-mac**: Beautiful, powerful chess app for the Mac
   - https://github.com/daylen/stockfish-mac
 
-#### Mac Exclusives
+### Mac Exclusives
 - **AnyBar**: OS X menubar status indicator
   - https://github.com/tonsky/AnyBar
 - **Awake**: An app for mac osx to prevent sleeping; inspired by Caffeine.
@@ -61,7 +61,7 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
   - https://github.com/eczarny/spectacle
 
 
-#### For Developers
+### For Developers
 - **App Reviews**: App Reviews help you keep track of user reviews for your iPhone Apps. :large_orange_diamond:
   - https://github.com/knutigro/AppReviews
 - **Cakebrew**: Manage your Homebrew formulas with style
@@ -77,7 +77,7 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
 - **VisualJSON**: JSON pretty-viewer for OS X.
   - https://github.com/youknowone/VisualJSON
 
-#### Tools
+### Tools
 - **Color Picker Pro**: Color Detection Tool for Designers and Developers
   - https://github.com/oscardelben/Color-Picker-Pro
 - **Gifs**: A Mac App for finding GIFs
@@ -99,7 +99,7 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
 - **VideoMessageExporter**: OSX app to export Skype video messages
   - https://github.com/alvarop/VideoMessageExporter
 
-#### OS X versions, GUIs and other Wrappers
+### OS X versions, GUIs and other Wrappers
 - **Cloudy**: mac app wrapper for overcast :large_orange_diamond:
   - https://github.com/calebd/cloudy
 - **CoinManager**: OS X app for Coinbase
@@ -113,7 +113,7 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
 - **tunnelblick**: Graphic user interface for OpenVPN
   - https://code.google.com/p/tunnelblick/
 
-#### Productivity and Others
+### Productivity and Others
 - **Catch**: Broadcasting made easy.
   - https://github.com/mipstian/catch
 - **ToDoOSX**: OS X app using Parse and managing Todos
@@ -121,10 +121,10 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
 - **Vienna**: RSS/Atom Reader
   - https://github.com/ViennaRSS/vienna-rss
 
-### Apple Sample Projects
+## Apple Sample Projects
 [Apple Sample Projects](https://developer.apple.com/library/mac/navigation/#section=Resource%20Types&topic=Sample%20Code)
 
-### Apple Open Source
+## Apple Open Source
 [Apple Open Source](http://www.opensource.apple.com/)
 
 ## Contact


### PR DESCRIPTION
I felt it was starting to get a bit messy, so I added categories.
- I'm still not sure about the distinction between "Mac Exclusives" and "Tools" as, they are both still tools, but without separating Operative System stuff like spetacle, awake, anybar, the list would get too large quickly.
- Some apps obviously fit in many categories, so I placed them in the most specific ones, in the best scenario we could sort them by tags, but not in a README I guess.
- Would be cool to sort them by stars aswell
- There are many huge lists for Open Source software, should we filter this by a certain criteria or not? Otherwise do all Mozilla apps, Chromium, Libre and Open Office and thousands others fit here?
