### PR TITLE
Add rake new and undo (easily add apps)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.README.bac.md

--- a/management.rb
+++ b/management.rb
@@ -1,0 +1,102 @@
+def makeFile(input)
+
+  backup = File.open(".README.bac.md", "r")
+  file = File.open("README.md", "w")
+  inCat = false
+  category = input [0]
+  app = input [1]
+  descr = input [2]
+  link = input [3]
+  text = structureText(app, descr, link)
+  backup.each do |line|
+    if inCat
+      lines = writeApp(app, line, text)
+      file.puts lines
+      # Trick, if multiple lines coming (place to write app found, then stop searching)
+      inCat = lines.one?
+    else
+      inCat = findCategory(category, line)
+      file.puts line
+    end
+  end
+end
+
+def structureText (app, descr, link)
+  textStructured = Array.new
+  textStructured[0] = ("- **" + app + "**: " + descr)
+  textStructured[1] = ("  - " + link)
+  return textStructured
+end
+
+def listCategories
+  file = File.open("README.md", "r")
+  inApps = false
+  categories = Array.new
+  file.each do |line|
+    if inApps
+      if line.include?("### ")
+        categories.push(line[4..-1])
+      end
+        inApps = line[0..2] != "## "
+    else
+      inApps = line.include?("## OS X Apps")
+    end
+  end
+  return categories
+end
+
+def findCategory (category, line)
+  return line.include? ("### " + category)
+end
+
+def writeApp (app, line, text)
+  if (line.length == 1 || findApp(app, line))
+    return [text[0], text[1], line]
+  else
+    return [line]
+  end
+end
+
+
+def findApp (app, line)
+  strings = line.scan(/\*\*.*\*\*:/)
+  if strings.empty?
+    return false
+  else
+    return compareApps(app, strings[0])
+  end
+end
+
+def compareApps(app, string)
+  app2 = string[2..(string.length-5)]
+  if (app.downcase < app2.downcase)
+    return true
+  else
+    return false
+  end
+end
+
+def main
+  puts "Name of app: "
+  app = gets.chomp
+  puts "App description: "
+  desc = gets.chomp
+  puts "App repository link: "
+  link = gets.chomp
+  puts "Choose one of the following categories"
+  categories = listCategories
+  n = 0
+  categories.each do |category|
+    puts n.to_s + ": " + category
+    n+=1
+  end
+  category = categories[gets.to_i]
+  makeFile([category, app, desc, link])
+  puts "New app successfully added"
+end
+
+main
+
+
+
+

--- a/rakefile
+++ b/rakefile
@@ -1,0 +1,12 @@
+desc "Add a new app"
+task :new do
+  %x[cp README.md .README.bac.md]
+  ruby "management.rb"
+end
+
+desc "Undo previous"
+task :undo do
+  %x[cp .README.bac.md README.md]
+end
+
+


### PR DESCRIPTION
Yo,

Honestly I found it too be to much of a pain to go through the file, find the Category and then put the app in alphabetic order because of that, (we are all lazy after all), I created a very basic, inefficient and likely terrible way of us doing it quicker. 

All you have to do is type 'rake new' in the directory and it will ask for the App name, description and link, then provide a list of category options to choose by number. Need to have ruby installed though.

The other function that I already placed is 'rake undo' to recover the previous file, (though git checkout -- README.md already does it, I opted for a git independent way). 

In the future, adding a new category, provide a list of apps in a category sound like good options. 

It was my first try with Ruby, so any tips/feedback are welcome as well as contributions of course!

I did not test too much, but so far so good.
