### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Visit this supporting repository here: [jeffreyjackson/mac-frameworks](https://g
 
 ### Web Browsers
 - **Firefox**: Cross-platform web browser
-  - https://hg.mozilla.org/mozilla-central/
+  - https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US
 - **TenFourFox**: A fork of Firefox to maintain support for the Power Mac, supporting Mac OS X 10.4 and 10.5
   - https://github.com/classilla/tenfourfox
 


### PR DESCRIPTION
@jeffreyjackson  Firefox: Cross-platform web browser should be pointed to [Firefox for Mac](https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US) 

https://hg.mozilla.org/mozilla-central/  is not Stable  it can work for developers but  its not good option for students/users may have issues 

