### PR TITLE
Add Lockpaw to Mac Interface Exclusives

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Visit this supporting repository here: [mac-frameworks](https://github.com/jeffr
   - https://github.com/JadenGeller/Helium
 - **KeepingYouAwake**: Prevents your Mac from going to sleep
   - https://github.com/newmarcel/KeepingYouAwake
+- **Lockpaw**: macOS menu bar screen guard — lock/unlock with a hotkey :large_orange_diamond:
+  - https://github.com/sorkila/lockpaw
 - **MenuMeters**: A is a set of CPU, memory, disk, and network monitoring tools for Mac OS X sitting in the menubar
   - https://github.com/yujitach/MenuMeters
 - **mirrorapp**: Mirror Enterprise iOS and OSX App


### PR DESCRIPTION
[Lockpaw](https://github.com/sorkila/lockpaw) is an open-source macOS menu bar screen guard. Lock and unlock your display with a global hotkey. Built with Swift, MIT licensed.

- 47+ GitHub stars
- Available via Homebrew
- Sparkle auto-updates