### PR TITLE
Add Clippy to Menubar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Visit this supporting repository here: [mac-frameworks](https://github.com/jeffr
   - [https://github.com/peterdsp/macmistral](https://github.com/peterdsp/macmistral)
 - **Americano**: Simple caffeinate wrapper stay at menu bar
   - [https://github.com/LZhenHong/Americano](https://github.com/LZhenHong/Americano)
+- **Clippy**: Card-based clipboard manager with content-aware previews, AI transformations, a built-in screenshot editor, and file converter :large_orange_diamond:
+  - [https://github.com/yarasaa/Clippy](https://github.com/yarasaa/Clippy)
 
 ## Apple Sample Projects
 [Apple Sample Projects](https://developer.apple.com/library/mac/navigation/#section=Resource%20Types&topic=Sample%20Code)


### PR DESCRIPTION
Adds **Clippy** to the `Menubar Apps` section.

## About
Clippy is an open-source (MIT) macOS menu-bar clipboard manager written in Swift/SwiftUI. Alongside a card-based history, it ships with:

- Content-aware previews for URLs, colors, JSON, code, images
- AI transformations (Ollama locally, or OpenAI / Anthropic / Google Gemini with your own key)
- Built-in screenshot editor with 20+ annotation tools
- File format converter (image / document / audio / video / data)
- Windows 11-style dock preview
- Shelf for drag-and-drop files

Repo: https://github.com/yarasaa/Clippy
License: MIT
Language: Swift (marked with :large_orange_diamond:)
Requires: macOS 13+