### PR TITLE
Add Featherbar to Mac Interface Exclusives

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Visit this supporting repository here: [mac-frameworks](https://github.com/jeffr
   - https://github.com/beltex/dshb
 - **Dockit**: An application that can dock any window to the edge of the screen.
   - https://github.com/xicheng148/Dockit
+- **Featherbar**: Featherweight menu-bar system monitor showing CPU, RAM, power, and temperature
+  - https://github.com/nim444/featherbar
 - **Helium**: A floating browser window for OS X :large_orange_diamond:
   - https://github.com/JadenGeller/Helium
 - **KeepingYouAwake**: Prevents your Mac from going to sleep


### PR DESCRIPTION
[Featherbar](https://github.com/nim444/featherbar) is an open-source (Apache-2.0) featherweight macOS menu-bar system monitor written in Rust. It shows CPU, RAM, power draw, and temperature in two color-coded menu bar lines, with zero background threads and flat ~20MB memory usage. Published on [crates.io](https://crates.io/crates/featherbar).

Added alphabetically to Mac Interface Exclusives.