### PR TITLE
Add Tintpad (For Developers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Visit this supporting repository here: [mac-frameworks](https://github.com/jeffr
   - https://github.com/youknowone/VisualJSON
 - **Tempo**: Replace the Git CLI with a clear UI and AI assist :large_orange_diamond:
   - https://github.com/maoyama/Tempo
+- **Tintpad**: Hotkey launcher that opens your terminal at the right repo with a coding agent (Claude Code, Codex) already running :large_orange_diamond:
+  - https://github.com/sorkila/tintpad
 
 ### Darwin Package Managers
 - **Fink**: The fink package manager for macOS (in Perl)


### PR DESCRIPTION
Adds Tintpad: a hotkey launcher that opens your terminal at the right repo with a coding agent (Claude Code, Codex, or any CLI agent) already running. Open source (MIT, marked with the diamond), native Swift, signed + notarized. Entry follows the list's two-line format.