### PR TITLE
Add ItsPaint to Productivity and Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ Visit this supporting repository here: [mac-frameworks](https://github.com/jeffr
   - https://github.com/clementine-player/Clementine
 - **GraphSketcher**: A fast, simple graph drawing and data plotting app for OS X and iPad from the Omni Group
   - https://github.com/graphsketcher/GraphSketcher
+- **ItsPaint**: MS Paint for the Mac — open it, draw, close it. 2.96 MB, written in Swift
+  - https://github.com/joshlin2201/itspaint
 - **Jekyll**: Blog-aware, static site generator in Ruby
   - https://github.com/jekyll/jekyll
 - **MacGesture**: Global mouse gesture for Mac OS X


### PR DESCRIPTION
Adds ItsPaint to **Productivity and Others**, alphabetically, next to Seashore.

[ItsPaint](https://github.com/joshlin2201/itspaint) is a small native paint and
markup app for macOS — MIT, written in Swift, 2.96 MB, universal and notarised.
Also free on the Mac App Store.

I'm the author. Happy to move it to **Tools** instead if that fits the list better.
