### PR TITLE
Add Pulse to Menubar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ Visit this supporting repository here: [mac-frameworks](https://github.com/jeffr
   - [https://github.com/yarasaa/Clippy](https://github.com/yarasaa/Clippy)
 - **Yap**: On-device voice dictation. Press a hotkey, talk, and the text is pasted into whatever field you were typing in. It runs offline in native Swift with no model to download.
   - [https://github.com/FrigadeHQ/yap](https://github.com/FrigadeHQ/yap)
+- **Pulse**: Menu bar system monitor with live CPU, memory, temperature, fan, network, disk, power, and battery stats
+  - [https://github.com/emgeorrk/pulse](https://github.com/emgeorrk/pulse)
 
 ## Apple Sample Projects
 [Apple Sample Projects](https://developer.apple.com/library/mac/navigation/#section=Resource%20Types&topic=Sample%20Code)


### PR DESCRIPTION
Adds **[Pulse](https://github.com/emgeorrk/pulse)** to the *Menubar Apps* section, following the section's format (no Swift diamond — it's written in Go).

Why it's worth adding:

- A feature-equivalent macOS counterpart of [Vitals](https://github.com/corecoding/Vitals), the popular GNOME Shell system-monitor extension that never existed on macOS — the same idea, rebuilt from scratch for the Mac.
- Free, open-source (MIT) menu bar system monitor with live CPU, memory, temperature, fan, network, disk, power, and battery stats.
- Reads everything from userspace — no sudo, no elevated privileges, no kernel extensions.
- Native app (Go + CGO over IOKit / SMC / HID / IOReport), tiny footprint, not Electron.
- Supports Apple Silicon and Intel; installable via a Homebrew tap or GitHub releases.
