### PR TITLE
Add Tracexy to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Visit this supporting repository here: [mac-frameworks](https://github.com/jeffr
   - https://github.com/Piero24/PlugNPlayMac
 - **Sigil**: Cross-platform editing software for EPUB files (e-books) written in C++, Qt
   - https://github.com/Sigil-Ebook/Sigil
+- **Tracexy**: Native, local-first network intelligence for live traffic and PCAP or PCAPNG investigation as app-aware sessions :large_orange_diamond:
+  - https://github.com/RockxyApp/Tracexy
 - **VideoMessageExporter**: OSX app to export Skype video messages
   - https://github.com/alvarop/VideoMessageExporter
 - **VLC**: Cross-platform media player and streaming media server written in C, C++, Qt, Objective-C


### PR DESCRIPTION
## Summary

Adds Tracexy to **Tools** as a native Swift macOS network intelligence application.

## Why

Tracexy captures live traffic or opens PCAP and PCAPNG files, then organizes protocol, process, flow, and packet evidence into app-aware sessions. The project is actively maintained, publicly released, and licensed under AGPL-3.0-or-later.

## Validation

- Confirmed Tracexy is not already listed or proposed.
- Used the repository’s two-line entry format and Swift project marker.
- Kept the entry alphabetically positioned between Sigil and VideoMessageExporter.
- Verified the public source repository returns HTTP 200.
- Ran `git diff --check`.

Disclosure: I am a Tracexy maintainer.