### PR TITLE
Add Rockxy to For Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Visit this supporting repository here: [mac-frameworks](https://github.com/jeffr
   - https://github.com/kykim/rem
 - **Resign**: OSX utility to resign the IPA files
   - https://github.com/LigeiaRowena/Resign
+- **Rockxy**: Native HTTP debugging proxy for intercepting HTTPS, inspecting APIs, mocking responses, and debugging WebSocket and GraphQL traffic :large_orange_diamond:
+  - https://github.com/RockxyApp/Rockxy
 - **Touch Bar Simulator**: Use the Touch Bar on any Mac :large_orange_diamond:
   - https://github.com/sindresorhus/touch-bar-simulator
 - **Unused** - A Mac app for checking Xcode projects for unused resources


### PR DESCRIPTION
## Summary

Adds Rockxy to **For Developers** as a native Swift macOS HTTP debugging proxy.

## Why

Rockxy intercepts HTTPS, inspects APIs, mocks responses, and debugs WebSocket and GraphQL traffic. The project is actively maintained, publicly released, and licensed under AGPL-3.0-or-later.

## Validation

- Confirmed Rockxy is not already listed or proposed.
- Used the repository’s two-line entry format and Swift project marker.
- Kept the entry alphabetically positioned between Resign and Touch Bar Simulator.
- Verified the public source repository returns HTTP 200.
- Ran `git diff --check`.

Disclosure: I am a Rockxy maintainer.