### PR TITLE
Add Shieldxy to Mac Interface Exclusives

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Visit this supporting repository here: [mac-frameworks](https://github.com/jeffr
   - https://github.com/SelfControlApp/selfcontrol
 - **Shady**: Menu bar app to dim Mac's screen
   - https://github.com/mattgemmell/Shady
+- **Shieldxy**: Auditable application firewall and connection monitor for macOS :large_orange_diamond:
+  - https://github.com/RockxyApp/Shieldxy
 - **tag**: A command line tool to manipulate tags on Mac OS X files, and to query for files with those tags
   - https://github.com/jdberry/tag
 - **Eul**: A macOS status monitoring app 


### PR DESCRIPTION
## Summary

Adds Shieldxy to **Mac Interface Exclusives** as a native Swift macOS application firewall and connection monitor.

## Why

Shieldxy provides an open-source, auditable view of application network connections and firewall controls. Version 0.1.1 is publicly released, and the source is licensed under AGPL-3.0-or-later.

## Validation

- Confirmed Shieldxy is not already listed or proposed.
- Used the repository’s two-line entry format and Swift project marker.
- Positioned the entry after Shady and before tag.
- Verified the public source repository returns HTTP 200 and is predominantly Swift.
- Ran `git diff --check`.

Disclosure: I am a Shieldxy maintainer.